### PR TITLE
Fix relative @view URLs

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -125,8 +125,9 @@ async function renderView(options: {
   let pane: PaneModule | undefined
   if (jsonld['@view']) {
     try {
-      console.log(`[solid-shim] Loading @view: ${jsonld['@view']}`)
-      const paneModule = await import(/* webpackIgnore: true */ jsonld['@view'])
+      const viewUrl = new URL(jsonld['@view'], window.location.href).href
+      console.log(`[solid-shim] Loading @view: ${viewUrl}`)
+      const paneModule = await import(/* webpackIgnore: true */ viewUrl)
       pane = paneModule.default || paneModule
     } catch (err) {
       console.warn(`[solid-shim] Failed to load @view "${jsonld['@view']}":`, err)


### PR DESCRIPTION
## Summary
- Resolve relative `@view` URLs against `window.location.href` before passing to `import()`
- Absolute URLs are unaffected (`new URL` is a no-op for them)

## Test plan
- Set `@view` to a relative path like `./src/panes/task.js` in a JSON-LD data island
- Confirm the pane loads correctly

Fixes #6